### PR TITLE
Suggestions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ You will need ModMenu and GlassConfigAPI to change stairs recipe output and twea
 
 ## List of changes
 
+* Allow editing signs with a feather (feather is consumed on use), default true.
+* Allow coloring signs with dye (dye is consumed on use), default true.
 * Disable creeper explosions breaking blocks, default false.
 * Disable ghast explosions causing fire, default false.
 * Disable ghast explosions breaking blocks, default false.

--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@ You will need ModMenu and GlassConfigAPI to change stairs recipe output and twea
 
 ## List of changes
 
-* Allow editing signs with a feather (feather is consumed on use), default true.
-* Allow coloring signs with dye (dye is consumed on use), default true.
+* Allow editing signs with a feather (feather is consumed on use), default false.
+* Allow coloring signs with dye (dye is consumed on use), default false.
+* Allow defusing TNT with shears (use left-click to defuse), default false.
 * Disable creeper explosions breaking blocks, default false.
 * Disable ghast explosions causing fire, default false.
 * Disable ghast explosions breaking blocks, default false.

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ yarn_mappings=b1.7.3-build.2
 loader_version=0.14.24-babric.1
 
 # Mod Properties
-mod_version=3.2.0
+mod_version=3.3.0
 maven_group=com.github.telvarost
 archives_base_name=MiscTweaks
 

--- a/src/main/java/com/github/telvarost/misctweaks/Config.java
+++ b/src/main/java/com/github/telvarost/misctweaks/Config.java
@@ -12,6 +12,14 @@ public class Config {
 
     public static class ConfigFields {
 
+        @ConfigName("Allow Editing Signs With A Feather")
+        @Comment("Feather will be consumed on use")
+        public static Boolean enableEditSignsWithFeathers = true;
+
+        @ConfigName("Allow Coloring Signs With Dye")
+        @Comment("Dye will be consumed on use")
+        public static Boolean enableColorSignsWithDye = true;
+
         @ConfigName("Disable Creeper Explosion Breaking Blocks")
         public static Boolean disableCreeperExplosionBreakingBlocks = false;
 

--- a/src/main/java/com/github/telvarost/misctweaks/Config.java
+++ b/src/main/java/com/github/telvarost/misctweaks/Config.java
@@ -21,7 +21,7 @@ public class Config {
         public static Boolean enableEditSignsWithFeathers = false;
 
         @ConfigName("Allow TNT Defusing With Shears")
-        @Comment("Use Left-Click with shears to cut the fuse")
+        @Comment("Use Left-Click with shears to defuse")
         public static Boolean enableDefusingTnt = false;
 
         @ConfigName("Disable Creeper Explosion Breaking Blocks")

--- a/src/main/java/com/github/telvarost/misctweaks/Config.java
+++ b/src/main/java/com/github/telvarost/misctweaks/Config.java
@@ -12,13 +12,17 @@ public class Config {
 
     public static class ConfigFields {
 
-        @ConfigName("Allow Editing Signs With A Feather")
-        @Comment("Feather will be consumed on use")
-        public static Boolean enableEditSignsWithFeathers = true;
-
         @ConfigName("Allow Coloring Signs With Dye")
         @Comment("Dye will be consumed on use")
-        public static Boolean enableColorSignsWithDye = true;
+        public static Boolean enableColorSignsWithDye = false;
+
+        @ConfigName("Allow Editing Signs With A Feather")
+        @Comment("Feather will be consumed on use")
+        public static Boolean enableEditSignsWithFeathers = false;
+
+        @ConfigName("Allow TNT Defusing With Shears")
+        @Comment("Use Left-Click with shears to cut the fuse")
+        public static Boolean enableDefusingTnt = false;
 
         @ConfigName("Disable Creeper Explosion Breaking Blocks")
         public static Boolean disableCreeperExplosionBreakingBlocks = false;
@@ -41,13 +45,13 @@ public class Config {
         @Comment("Restart required for modded variant only")
         public static Boolean modernDispenserFluidPlacement = false;
 
+        @ConfigName("Shapeless Jack o’ Lantern Recipe")
+        @Comment("Restart required for changes to take effect")
+        public static Boolean enableShapelessJackOLanternRecipe = true;
+
         @ConfigName("Stairs Crafting Recipe Output: 1-16")
         @Comment("Restart required for changes to take effect")
         @MaxLength(16)
         public static Integer stairsOutput = 4;
-
-        @ConfigName("Shapeless Jack o’ Lantern Recipe")
-        @Comment("Restart required for changes to take effect")
-        public static Boolean enableShapelessJackOLanternRecipe = true;
     }
 }

--- a/src/main/java/com/github/telvarost/misctweaks/mixin/CreeperMixin.java
+++ b/src/main/java/com/github/telvarost/misctweaks/mixin/CreeperMixin.java
@@ -2,9 +2,11 @@ package com.github.telvarost.misctweaks.mixin;
 
 import com.github.telvarost.misctweaks.Config;
 import com.github.telvarost.misctweaks.ModHelper;
+import net.minecraft.entity.EntityBase;
 import net.minecraft.entity.monster.Creeper;
 import net.minecraft.entity.monster.MonsterBase;
 import net.minecraft.level.Level;
+import net.minecraft.sortme.Explosion;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
@@ -21,16 +23,16 @@ public class CreeperMixin extends MonsterBase {
             method = "tryAttack",
             at = @At(
                     value = "INVOKE",
-                    target = "Lnet/minecraft/entity/monster/Creeper;remove()V"
+                    target = "Lnet/minecraft/entity/monster/Creeper;isCharged()Z"
             )
     )
-    public void miscTweaks_tryAttack(Creeper instance) {
+    public boolean miscTweaks_tryAttackBeforeCreateExplosion(Creeper instance) {
         if (Config.ConfigFields.disableCreeperExplosionBreakingBlocks)
         {
             ModHelper.ModHelperFields.cancelDestroyBlocks = true;
         }
 
-        instance.remove();
+        return instance.isCharged();
     }
 
 }

--- a/src/main/java/com/github/telvarost/misctweaks/mixin/DyeMixin.java
+++ b/src/main/java/com/github/telvarost/misctweaks/mixin/DyeMixin.java
@@ -1,0 +1,64 @@
+package com.github.telvarost.misctweaks.mixin;
+
+import com.github.telvarost.misctweaks.Config;
+import net.minecraft.block.BlockBase;
+import net.minecraft.entity.player.PlayerBase;
+import net.minecraft.item.Dye;
+import net.minecraft.item.ItemBase;
+import net.minecraft.item.ItemInstance;
+import net.minecraft.level.Level;
+import net.minecraft.tileentity.TileEntitySign;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(Dye.class)
+public class DyeMixin extends ItemBase {
+
+    public DyeMixin(int i) {
+        super(i);
+        this.setHasSubItems(true);
+        this.setDurability(0);
+    }
+
+    @Inject(method = "useOnTile", at = @At("HEAD"), cancellable = true)
+    public void useOnTile(ItemInstance arg, PlayerBase arg2, Level arg3, int i, int j, int k, int l, CallbackInfoReturnable<Boolean> cir) {
+        if (!Config.ConfigFields.enableColorSignsWithDye) {
+            return;
+        }
+
+        if (null == arg) {
+            return;
+        }
+
+        int blockId = arg3.getTileId(i, j, k);
+
+        if (  (BlockBase.STANDING_SIGN.id == blockId)
+           || (BlockBase.WALL_SIGN.id == blockId)
+        ) {
+            boolean dyeWasUsed = false;
+            char[] dyeColor = new char[]{'0', '4', '2', '9', '1', '5', '3', '7', '8', 'c', 'a', 'e', 'b', 'd', '6', 'f'};
+
+            TileEntitySign var8 = (TileEntitySign)arg3.getTileEntity(i, j, k);
+            if (var8 != null) {
+                for (int lineIndex = 0; lineIndex < var8.lines.length; lineIndex++) {
+                    if (!var8.lines[lineIndex].contains("§")) {
+                        var8.lines[lineIndex] = "§" + dyeColor[arg.getDamage()] + var8.lines[lineIndex];
+                        dyeWasUsed = true;
+                    } else if (!var8.lines[lineIndex].contains("§" + dyeColor[arg.getDamage()])) {
+                        String tempString = var8.lines[lineIndex].substring(2);
+                        var8.lines[lineIndex] = "§" + dyeColor[arg.getDamage()] + tempString;
+                        dyeWasUsed = true;
+                    }
+                }
+            }
+
+            if (dyeWasUsed) {
+                --arg.count;
+            }
+
+            cir.setReturnValue(true);
+        }
+    }
+}

--- a/src/main/java/com/github/telvarost/misctweaks/mixin/EditSignMixin.java
+++ b/src/main/java/com/github/telvarost/misctweaks/mixin/EditSignMixin.java
@@ -1,0 +1,59 @@
+package com.github.telvarost.misctweaks.mixin;
+
+
+import com.github.telvarost.misctweaks.Config;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.minecraft.client.gui.screen.ScreenBase;
+import net.minecraft.client.gui.screen.ingame.EditSign;
+import net.minecraft.tileentity.TileEntitySign;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import static net.minecraft.util.CharacterUtils.validCharacters;
+
+@Environment(EnvType.CLIENT)
+@Mixin(EditSign.class)
+public class EditSignMixin extends ScreenBase {
+
+    @Shadow private int cursorPos;
+
+    @Shadow private TileEntitySign entity;
+
+    @Inject(method = "keyPressed", at = @At("HEAD"), cancellable = true)
+    protected void keyPressed(char c, int i, CallbackInfo ci) {
+        if (!Config.ConfigFields.enableColorSignsWithDye) {
+            return;
+        }
+
+        if (i == 200) {
+            this.cursorPos = this.cursorPos - 1 & 3;
+        }
+
+        if (i == 208 || i == 28) {
+            this.cursorPos = this.cursorPos + 1 & 3;
+        }
+
+        if (i == 14 && this.entity.lines[this.cursorPos].length() > 0) {
+            this.entity.lines[this.cursorPos] = this.entity.lines[this.cursorPos].substring(0, this.entity.lines[this.cursorPos].length() - 1);
+        }
+
+        /** - Skip first instance of a section character with its modifier */
+        int lineLength = this.entity.lines[this.cursorPos].length();
+        if (this.entity.lines[this.cursorPos].contains("§")) {
+            lineLength = lineLength - 2;
+        }
+
+        if (validCharacters.indexOf(c) >= 0 && lineLength < 15) {
+            StringBuilder var10000 = new StringBuilder();
+            String[] var10002 = this.entity.lines;
+            int var10004 = this.cursorPos;
+            var10002[var10004] = var10000.append(var10002[var10004]).append(c).toString();
+        }
+
+        ci.cancel();
+    }
+}

--- a/src/main/java/com/github/telvarost/misctweaks/mixin/ExplosionMixin.java
+++ b/src/main/java/com/github/telvarost/misctweaks/mixin/ExplosionMixin.java
@@ -3,45 +3,44 @@ package com.github.telvarost.misctweaks.mixin;
 import com.github.telvarost.misctweaks.ModHelper;
 import net.minecraft.level.Level;
 import net.minecraft.sortme.Explosion;
+import org.objectweb.asm.Opcodes;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
 import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 
 @Mixin(Explosion.class)
 public class ExplosionMixin {
 
-    @Redirect(
-            method = "kaboomPhase2",
-            at = @At(
-                    value = "INVOKE",
-                    target = "Ljava/util/List;addAll(Ljava/util/Collection;)Z"
-            )
-    )
-    public boolean miscTweaks_addBlocksToDamage(List instance, Collection<?> es) {
+    @Shadow public Set damagedTiles;
+
+
+    @Inject(method = "kaboomPhase2", at = @At("HEAD"), cancellable = true)
+    public void miscTweaks_addBlocksToDamage(boolean par1, CallbackInfo ci) {
         if (ModHelper.ModHelperFields.cancelDestroyBlocks) {
-            ModHelper.ModHelperFields.numberOfDamagedBlocks += es.size();
+            ModHelper.ModHelperFields.numberOfDamagedBlocks += this.damagedTiles.size();
             ModHelper.ModHelperFields.cancelDestroyBlocks = false;
         }
-
-        return instance.addAll(es);
     }
 
-    @Redirect(
+    @ModifyVariable(
             method = "kaboomPhase2",
-            at = @At(
-                    value = "INVOKE",
-                    target = "Lnet/minecraft/level/Level;getTileId(III)I"
-            )
+            at = @At(value = "STORE"),
+            ordinal = 3
     )
-    public int miscTweaks_kaboomPhase2(Level instance, int j, int k, int i) {
+    public int miscTweaks_kaboomPhase2(int tileId) {
         if (0 < ModHelper.ModHelperFields.numberOfDamagedBlocks) {
             ModHelper.ModHelperFields.numberOfDamagedBlocks--;
             return 0;
         } else {
-            return instance.getTileId(i, j , k);
+            return tileId;
         }
     }
 

--- a/src/main/java/com/github/telvarost/misctweaks/mixin/ItemBaseMixin.java
+++ b/src/main/java/com/github/telvarost/misctweaks/mixin/ItemBaseMixin.java
@@ -1,0 +1,48 @@
+package com.github.telvarost.misctweaks.mixin;
+
+
+import com.github.telvarost.misctweaks.Config;
+import net.minecraft.block.BlockBase;
+import net.minecraft.entity.player.PlayerBase;
+import net.minecraft.item.ItemBase;
+import net.minecraft.item.ItemInstance;
+import net.minecraft.level.Level;
+import net.minecraft.tileentity.TileEntitySign;
+import net.modificationstation.stationapi.api.client.item.StationRendererItem;
+import net.modificationstation.stationapi.api.item.StationFlatteningItem;
+import net.modificationstation.stationapi.api.item.StationItem;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(ItemBase.class)
+public class ItemBaseMixin implements StationFlatteningItem, StationItem, StationRendererItem {
+
+    @Shadow public static ItemBase feather;
+
+    @Shadow public static ItemBase dyePowder;
+
+    @Inject(method = "useOnTile", at = @At("HEAD"), cancellable = true)
+    public void useOnTile(ItemInstance arg, PlayerBase arg2, Level arg3, int i, int j, int k, int l, CallbackInfoReturnable<Boolean> cir) {
+        if (Config.ConfigFields.enableEditSignsWithFeathers) {
+            if (feather.id == arg.itemId) {
+                int blockId = arg3.getTileId(i, j, k);
+
+                if (  (BlockBase.STANDING_SIGN.id == blockId)
+                   || (BlockBase.WALL_SIGN.id == blockId)
+                ) {
+                    --arg.count;
+
+                    TileEntitySign var8 = (TileEntitySign)arg3.getTileEntity(i, j, k);
+                    if (var8 != null) {
+                        arg2.openSignScreen(var8);
+                    }
+
+                    cir.setReturnValue(true);
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/github/telvarost/misctweaks/mixin/ItemBaseMixin.java
+++ b/src/main/java/com/github/telvarost/misctweaks/mixin/ItemBaseMixin.java
@@ -3,9 +3,14 @@ package com.github.telvarost.misctweaks.mixin;
 
 import com.github.telvarost.misctweaks.Config;
 import net.minecraft.block.BlockBase;
+import net.minecraft.client.Minecraft;
+import net.minecraft.entity.EntityBase;
+import net.minecraft.entity.Item;
+import net.minecraft.entity.PrimedTnt;
 import net.minecraft.entity.player.PlayerBase;
 import net.minecraft.item.ItemBase;
 import net.minecraft.item.ItemInstance;
+import net.minecraft.item.tool.Shears;
 import net.minecraft.level.Level;
 import net.minecraft.tileentity.TileEntitySign;
 import net.modificationstation.stationapi.api.client.item.StationRendererItem;
@@ -22,26 +27,52 @@ public class ItemBaseMixin implements StationFlatteningItem, StationItem, Statio
 
     @Shadow public static ItemBase feather;
 
-    @Shadow public static ItemBase dyePowder;
+    @Shadow public static Shears shears;
+
+    @Inject(method = "getAttack", at = @At("HEAD"), cancellable = true)
+    public void getAttack(EntityBase arg, CallbackInfoReturnable<Integer> cir) {
+        if (!Config.ConfigFields.enableDefusingTnt) {
+            return;
+        }
+
+        ItemBase thisItem = ((ItemBase) (Object)this);
+
+        if (thisItem.id == shears.id) {
+            if (null != arg && PrimedTnt.class == arg.getClass()) {
+                PrimedTnt thisTnt = (PrimedTnt) arg;
+                Minecraft minecraft = MinecraftAccessor.getInstance();
+
+                if (!minecraft.level.isServerSide) {
+                    Item var24 = new Item(minecraft.level, thisTnt.x, thisTnt.y, thisTnt.z, new ItemInstance(BlockBase.TNT));
+                    var24.velocityY = 0.20000000298023224;
+                    minecraft.level.spawnEntity(var24);
+
+                    thisTnt.remove();
+                }
+            }
+        }
+    }
 
     @Inject(method = "useOnTile", at = @At("HEAD"), cancellable = true)
     public void useOnTile(ItemInstance arg, PlayerBase arg2, Level arg3, int i, int j, int k, int l, CallbackInfoReturnable<Boolean> cir) {
-        if (Config.ConfigFields.enableEditSignsWithFeathers) {
-            if (feather.id == arg.itemId) {
-                int blockId = arg3.getTileId(i, j, k);
+        if (!Config.ConfigFields.enableEditSignsWithFeathers) {
+            return;
+        }
 
-                if (  (BlockBase.STANDING_SIGN.id == blockId)
-                   || (BlockBase.WALL_SIGN.id == blockId)
-                ) {
-                    --arg.count;
+        if (feather.id == arg.itemId) {
+            int blockId = arg3.getTileId(i, j, k);
 
-                    TileEntitySign var8 = (TileEntitySign)arg3.getTileEntity(i, j, k);
-                    if (var8 != null) {
-                        arg2.openSignScreen(var8);
-                    }
+            if (  (BlockBase.STANDING_SIGN.id == blockId)
+                    || (BlockBase.WALL_SIGN.id == blockId)
+            ) {
+                --arg.count;
 
-                    cir.setReturnValue(true);
+                TileEntitySign var8 = (TileEntitySign)arg3.getTileEntity(i, j, k);
+                if (var8 != null) {
+                    arg2.openSignScreen(var8);
                 }
+
+                cir.setReturnValue(true);
             }
         }
     }

--- a/src/main/java/com/github/telvarost/misctweaks/mixin/MinecraftAccessor.java
+++ b/src/main/java/com/github/telvarost/misctweaks/mixin/MinecraftAccessor.java
@@ -1,0 +1,13 @@
+package com.github.telvarost.misctweaks.mixin;
+
+import net.minecraft.client.Minecraft;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(Minecraft.class)
+public interface MinecraftAccessor {
+    @Accessor(value = "instance")
+    static Minecraft getInstance() {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/src/main/java/com/github/telvarost/misctweaks/mixin/PrimedTntMixin.java
+++ b/src/main/java/com/github/telvarost/misctweaks/mixin/PrimedTntMixin.java
@@ -1,0 +1,38 @@
+//package com.github.telvarost.misctweaks.mixin;
+//
+//import net.minecraft.block.BlockBase;
+//import net.minecraft.client.Minecraft;
+//import net.minecraft.entity.EntityBase;
+//import net.minecraft.entity.Item;
+//import net.minecraft.entity.PrimedTnt;
+//import net.minecraft.entity.player.PlayerBase;
+//import net.minecraft.item.ItemBase;
+//import net.minecraft.item.ItemInstance;
+//import net.minecraft.level.Level;
+//import org.spongepowered.asm.mixin.Mixin;
+//
+//@Mixin(PrimedTnt.class)
+//abstract class PrimedTntMixin extends EntityBase {
+//
+//    public PrimedTntMixin(Level arg) {
+//        super(arg);
+//    }
+//
+//    @Override
+//    public boolean interact(PlayerBase arg) {
+//        ItemInstance var2 = arg.inventory.getHeldItem();
+//        if (var2 != null && var2.itemId == ItemBase.shears.id) {
+//            if (!this.level.isServerSide) {
+//
+//                Minecraft thisMinecraft = MinecraftAccessor.getInstance();
+//                Item var24 = new Item(thisMinecraft.level, this.x, this.y, this.z, new ItemInstance(BlockBase.TNT));
+//                var24.velocityY = 0.20000000298023224;
+//                thisMinecraft.level.spawnEntity(var24);
+//
+//                this.remove();
+//            }
+//        }
+//
+//        return false;
+//    }
+//}

--- a/src/main/java/com/github/telvarost/misctweaks/mixin/TileEntitySignMixin.java
+++ b/src/main/java/com/github/telvarost/misctweaks/mixin/TileEntitySignMixin.java
@@ -1,0 +1,45 @@
+package com.github.telvarost.misctweaks.mixin;
+
+import com.github.telvarost.misctweaks.Config;
+import net.minecraft.tileentity.TileEntityBase;
+import net.minecraft.tileentity.TileEntitySign;
+import net.minecraft.util.io.CompoundTag;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(TileEntitySign.class)
+public class TileEntitySignMixin extends TileEntityBase {
+
+    @Shadow private boolean needsInitializing;
+
+    @Shadow public String[] lines;
+
+    @Inject(method = "readIdentifyingData", at = @At("HEAD"), cancellable = true)
+    public void readIdentifyingData(CompoundTag arg, CallbackInfo ci) {
+        if (!Config.ConfigFields.enableColorSignsWithDye) {
+            return;
+        }
+
+        this.needsInitializing = false;
+        super.readIdentifyingData(arg);
+
+        for(int var2 = 0; var2 < 4; ++var2) {
+            this.lines[var2] = arg.getString("Text" + (var2 + 1));
+
+            /** - Allow first instance of a section character with its modifier */
+            int lineLimit = 15;
+            if (this.lines[var2].contains("§")) {
+                lineLimit = lineLimit + 2;
+            }
+
+            if (this.lines[var2].length() > lineLimit) {
+                this.lines[var2] = this.lines[var2].substring(0, lineLimit);
+            }
+        }
+
+        ci.cancel();
+    }
+}

--- a/src/main/resources/misctweaks.mixins.json
+++ b/src/main/resources/misctweaks.mixins.json
@@ -12,6 +12,7 @@
     "FluidMixin",
     "GhastMixin",
     "ItemBaseMixin",
+    "MinecraftAccessor",
     "TileEntityDispenserMixin",
     "TileEntitySignMixin"
   ],

--- a/src/main/resources/misctweaks.mixins.json
+++ b/src/main/resources/misctweaks.mixins.json
@@ -6,15 +6,19 @@
   "mixins": [
     "CreeperMixin",
     "DispenserMixin",
+    "DyeMixin",
     "ExplosionMixin",
     "FireballMixin",
     "FluidMixin",
     "GhastMixin",
-    "TileEntityDispenserMixin"
+    "ItemBaseMixin",
+    "TileEntityDispenserMixin",
+    "TileEntitySignMixin"
   ],
   "server": [
   ],
   "client": [
+    "EditSignMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
## What's Changed
### Added
* Allow editing signs with a feather (feather is consumed on use), default false.
* Allow coloring signs with dye (dye is consumed on use), default false.
* Allow defusing TNT with shears (use left-click to defuse), default false.
### Changed
* Fix all explosions being disabled even when creeper and ghast explosions are enabled.